### PR TITLE
updated terraform with eventbridge and updated load script

### DIFF
--- a/pipeline/load.py
+++ b/pipeline/load.py
@@ -34,7 +34,7 @@ def get_judge_id(conn: connect, judge_name: str) -> int | None:
                 """,
                     (judge_name,)
                     )
-    result = cur.fetchone()
+        result = cur.fetchone()
     if result:
         return result[0]
     return None
@@ -51,7 +51,7 @@ def upload_case_data(conn: connect, cases_df: pd.DataFrame) -> None:
 
     with conn.cursor() as cur:
         query = """
-                        INSERT INTO case
+                        INSERT INTO court_case
                             (case_no_id, title, judge_id, verdict, summary, transcript_date)
                         VALUES
                             (%s, %s, %s, %s, %s, %s)

--- a/terraform/eventbridge.tf
+++ b/terraform/eventbridge.tf
@@ -1,0 +1,21 @@
+# Create the eventbridge rules for ETL
+
+resource "aws_lambda_permission" "allow_event_bridge" {
+  statement_id  = "AllowExecutionFromEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.court-pipeline-terraform.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.court-pipeline-terraform.arn
+}
+
+resource "aws_cloudwatch_event_rule" "court-pipeline-terraform" {
+  name                = "c10-court-pipeline-terraform"
+  description         = "Triggers court transript ETL every day"
+  schedule_expression = "cron(0 18 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "lambda_target" {
+  rule      = aws_cloudwatch_event_rule.court-pipeline-terraform.name
+  target_id = "MyLambdaFunctionTarget"
+  arn       = aws_lambda_function.court-pipeline-terraform.arn
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,44 @@
-# Create the cloud platform
+# Create the cloud platform and database
 
 provider "aws" {
     region = "eu-west-2"
     access_key = var.AWS_KEY
     secret_key = var.AWS_SKEY
+}
+
+data "aws_db_subnet_group" "public_subnet_group" {
+    name = "public_subnet_group"
+}
+
+data "aws_vpc" "cohort_10_vpc" {
+    id = "vpc-0c4f01396d92e1cc7"
+}
+
+resource "aws_security_group" "rds_security_group" {
+    name = "c10-court-db-secgroup-terraform"
+    description = "Allows inbound Postgres access"
+    vpc_id = data.aws_vpc.cohort_10_vpc.id
+
+    ingress {
+        cidr_blocks       = ["0.0.0.0/0"]
+        from_port         = 5432
+        protocol          = "tcp"
+        to_port           = 5432
+    }
+}
+
+resource "aws_db_instance" "court-db" {
+  allocated_storage            = 10
+  db_name                      = "court_transcript"
+  identifier                   = "c10-court-transcript-db"
+  engine                       = "postgres"
+  engine_version               = "16.1"
+  instance_class               = "db.t3.micro"
+  username                     = var.DB_USER
+  password                     = var.DB_PASSWORD
+  publicly_accessible          = true
+  performance_insights_enabled = false
+  skip_final_snapshot          = true
+  db_subnet_group_name         = data.aws_db_subnet_group.public_subnet_group.name
+  vpc_security_group_ids       = [aws_security_group.rds_security_group.id]
 }

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -36,7 +36,7 @@ resource "aws_iam_role_policy" "lambda_policy" {
   })
 }
 
-resource "aws_lambda_function" "ord-lmnh-pipeline-terraform" {
+resource "aws_lambda_function" "court-pipeline-terraform" {
   function_name = "c10-court-pipeline-terraform"
 
   package_type  = "Image"


### PR DESCRIPTION
- added eventbridge rule for running ETL every day at closing work day hour of 6pm.
- Changed bug in load script where fetching was occurring after cursor was closed when fetching data from database.

closes #59 