### PR TITLE
add terraformed load balancing for products

### DIFF
--- a/terraform/dashboard.tf
+++ b/terraform/dashboard.tf
@@ -10,6 +10,13 @@ resource "aws_security_group" "court-dashboard-sec-group" {
         to_port           = 8200
     }
 
+    ingress {
+        cidr_blocks       = ["0.0.0.0/0"]
+        from_port         = 80
+        protocol          = "tcp"
+        to_port           = 80
+    }
+
   egress {
     from_port        = 0
     to_port          = 0
@@ -62,12 +69,45 @@ resource "aws_ecs_task_definition" "court-dashboard-task-definition" {
     ])
 }
 
+resource "aws_alb" "court_dashboard_alb" {
+  name               = "c10-court-dashboard-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.court-dashboard-sec-group.id]
+  subnets            = ["subnet-0f1bc89d0670672b5", "subnet-010c8f9ace38ac103", "subnet-05a01546985e339a6"]
+}
+
+resource "aws_alb_listener" "dashboard_front_end" {
+  load_balancer_arn = aws_alb.court_dashboard_alb.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = aws_alb_target_group.alb-court-dashboard-tg.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_alb_target_group" "alb-court-dashboard-tg" {
+  name        = "c10-court-dashboard-lb-alb-tg"
+  port        = 8200
+  protocol    = "HTTP"
+  vpc_id      = var.VPC_ID
+  target_type = "ip"
+}
+
 resource "aws_ecs_service" "court-dashboard-service" {
     name = "c10-court-dashboard-service"
     cluster = data.aws_ecs_cluster.c10-ecs-cluster.cluster_name
     task_definition = aws_ecs_task_definition.court-dashboard-task-definition.arn
     desired_count = 1
     launch_type = "FARGATE"
+
+    load_balancer {
+      target_group_arn = aws_alb_target_group.alb-court-dashboard-tg.arn
+      container_name = "court-dashboard-td"
+      container_port = 8200
+    }
     network_configuration {
       subnets = ["subnet-0f1bc89d0670672b5", "subnet-010c8f9ace38ac103", "subnet-05a01546985e339a6"]
       security_groups = [aws_security_group.court-dashboard-sec-group.id]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,11 +11,11 @@ data "aws_db_subnet_group" "public_subnet_group" {
 }
 
 data "aws_vpc" "cohort_10_vpc" {
-    id = var.VPC_GROUP
+    id = var.VPC_ID
 }
 
 data "aws_ecs_cluster" "c10-ecs-cluster" {
-    cluster_name = var.VPC_GROUP
+    cluster_name = var.ECS_CLUSTER
 }
 
 data "aws_iam_role" "execution-role" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -62,7 +62,7 @@ variable "SUBNET_GROUP" {
   type = string
 }
 
-variable "VPC_GROUP" {
+variable "VPC_ID" {
   type = string
   sensitive = true
 }


### PR DESCRIPTION
Added the scripts for terraforming load balanced instances of API and Dashboard.
- The address created on AWS redirects to the IP address of the products respectively.
- Ports no longer need to be implemented when accessing products.

closes #204 
closes #205 