### PR TITLE
updated dockerfile to catch new directory

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -12,5 +12,6 @@ COPY charts.py .
 COPY case_profiles.py .
 COPY layout.py .
 COPY .streamlit/config.toml .streamlit/config.toml
+COPY pages/1_Charts.py pages/1_Charts.py
 
 CMD streamlit run streamlit_app.py --server.port 8200


### PR DESCRIPTION
- Bug caused the docker file to not run dashboard without failing.
- Caused by new `pages` folder
- Added `pages/1_Charts.py` to dockerfile to make it run properly.